### PR TITLE
fix(secretize): fix feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["zeroize"]
-zeroize = ["zeroize/default"]
+default = []
 base64 = ["base64/default"]
 serde = ["serde/default"]
 openapi = ["poem-openapi", "serde_json"]
@@ -26,7 +25,6 @@ version = "1.0"
 
 [dependencies.zeroize]
 version = "1.5"
-optional = true
 
 [dependencies.base64]
 version = "0.21"

--- a/justfile
+++ b/justfile
@@ -23,3 +23,4 @@
     cargo test --features base64,openapi
     cargo test --features eq
     cargo test --all-features
+    cargo test --no-default-features


### PR DESCRIPTION
Previously "zerioize" was an optional dependency, but secretize won't compile with '--no-default-features'.